### PR TITLE
refactor: Reward GraphQL (Update conditions and Deprecate rule_type)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -39,6 +39,7 @@ services:
       - DATABASE_DSN=postgres://user:pass@postgres:5432/rewards?sslmode=disable
       - PORT=8082
       - LOG_LEVEL=debug
+      - ENV=dev
     depends_on:
       postgres:
         condition: service_healthy
@@ -58,6 +59,7 @@ services:
       - KAFKA_CONSUMER_TOPICS=learning-events
       - KAFKA_CONSUMER_GROUP=reward-processor
       - LOG_LEVEL=debug
+      - ENV=dev
     depends_on:
       kafka:
         condition: service_healthy

--- a/reward-processor/README.md
+++ b/reward-processor/README.md
@@ -44,7 +44,55 @@ The service can be configured using environment variables:
 
 The service exposes a GraphQL API for managing reward rules. The API is available at `/graphql` endpoint.
 
-### Queries
+### Schema Overview
+
+#### Types
+
+##### Rule
+- `id`: ID! - Unique identifier
+- `eventType`: String! - Type of event to match
+- `count`: Int - Required count for milestone rules
+- `conditions`: RuleConditions - Structured conditions object
+- `reward`: Reward! - Reward configuration
+- `enabled`: Boolean! - Whether the rule is active
+
+##### RuleConditions
+- `category`: String - Category to match against event data
+
+##### Reward
+- `type`: RewardType! - Reward type (BADGE or POINTS)
+- `amount`: Int - Reward amount (for point-based rewards)
+- `description`: String! - Human-readable description
+
+##### RewardType (Enum)
+- `BADGE` - Badge-based rewards
+- `POINTS` - Point-based rewards
+
+#### Input Types
+
+##### CreateRuleInput
+- `eventType`: String! - Type of event to match
+- `count`: Int - Required count for milestone rules
+- `conditions`: RuleConditionsInput - Rule conditions
+- `reward`: RewardInput! - Reward configuration
+- `enabled`: Boolean! - Whether the rule is active
+
+##### UpdateRuleInput
+- `eventType`: String - Type of event to match
+- `count`: Int - Required count for milestone rules
+- `conditions`: RuleConditionsInput - Rule conditions
+- `reward`: RewardInput - Reward configuration
+- `enabled`: Boolean - Whether the rule is active
+
+##### RuleConditionsInput
+- `category`: String! - Required category to match
+
+##### RewardInput
+- `type`: RewardType! - Reward type (BADGE or POINTS)
+- `amount`: Int - Reward amount (for point-based rewards)
+- `description`: String! - Human-readable description
+
+### Example Queries
 
 #### List All Rules
 ```graphql
@@ -86,7 +134,7 @@ query {
 }
 ```
 
-### Mutations
+### Example Mutations
 
 #### Create Rule
 ```graphql
@@ -98,14 +146,13 @@ mutation {
       category: "MATH"
     }
     reward: {
-      type: "POINTS"
+      type: POINTS
       amount: 100
       description: "Completed 5 math courses"
     }
     enabled: true
   }) {
     id
-    type
     eventType
     count
     conditions {
@@ -132,14 +179,13 @@ mutation {
         category: "SCIENCE"
       }
       reward: {
-        type: "POINTS"
+        type: POINTS
         amount: 200
         description: "Updated reward description"
       }
     }
   ) {
     id
-    type
     eventType
     count
     conditions {
@@ -152,66 +198,6 @@ mutation {
     }
     enabled
   }
-}
-```
-
-### Types
-
-#### Rule
-- `id`: Unique identifier
-- `eventType`: Type of event to match
-- `count`: Required count for milestone rules
-- `conditions`: Structured conditions object with category field
-- `reward`: Reward configuration
-- `enabled`: Whether the rule is active
-
-#### RuleConditions
-- `category`: Category to match against event data
-
-#### Reward
-- `type`: Reward type (e.g., `POINTS`, `BADGE`)
-- `amount`: Reward amount (for point-based rewards)
-- `description`: Human-readable description
-
-## Rule Types
-
-### Single Event Rule
-
-Triggers a reward when a single event matches the conditions:
-
-```json
-{
-  "id": "rule-001",
-  "event_type": "COURSE_COMPLETED",
-  "conditions": {
-    "category": "MATH"
-  },
-  "reward": {
-    "type": "BADGE",
-    "description": "Finished a Math course"
-  },
-  "enabled": true
-}
-```
-
-### Milestone Rule
-
-Tracks event counts in the database and triggers when the target is reached:
-
-```json
-{
-  "id": "rule-002",
-  "event_type": "COURSE_COMPLETED",
-  "count": 5,
-  "conditions": {
-    "category": "MATH"
-  },
-  "reward": {
-    "type": "POINTS",
-    "amount": 100,
-    "description": "Completed 5 math courses"
-  },
-  "enabled": true
 }
 ```
 
@@ -273,4 +259,3 @@ Run the test suite:
 ```bash
 go test ./...
 ```
-

--- a/reward-processor/README.md
+++ b/reward-processor/README.md
@@ -51,7 +51,6 @@ The service exposes a GraphQL API for managing reward rules. The API is availabl
 query {
   rules {
     id
-    type
     eventType
     count
     conditions
@@ -70,7 +69,6 @@ query {
 query {
   rule(id: "rule-001") {
     id
-    type
     eventType
     count
     conditions
@@ -90,7 +88,6 @@ query {
 ```graphql
 mutation {
   createRule(input: {
-    type: "MILESTONE"
     eventType: "COURSE_COMPLETED"
     count: 5
     conditions: {
@@ -151,7 +148,6 @@ mutation {
 
 #### Rule
 - `id`: Unique identifier
-- `type`: Rule type (`SINGLE_EVENT` or `MILESTONE`)
 - `eventType`: Type of event to match
 - `count`: Required count for milestone rules
 - `conditions`: JSON object with matching conditions
@@ -172,7 +168,6 @@ Triggers a reward when a single event matches the conditions:
 ```json
 {
   "id": "rule-001",
-  "type": "SINGLE_EVENT",
   "event_type": "COURSE_COMPLETED",
   "conditions": {
     "category": "MATH"
@@ -192,7 +187,6 @@ Tracks event counts in the database and triggers when the target is reached:
 ```json
 {
   "id": "rule-002",
-  "type": "MILESTONE",
   "event_type": "COURSE_COMPLETED",
   "count": 5,
   "conditions": {
@@ -266,7 +260,3 @@ Run the test suite:
 go test ./...
 ```
 
-The test suite includes:
-- Unit tests for the rules engine
-- Integration tests for database operations
-- Mock tests for Kafka interactions

--- a/reward-processor/README.md
+++ b/reward-processor/README.md
@@ -53,7 +53,9 @@ query {
     id
     eventType
     count
-    conditions
+    conditions {
+      category
+    }
     reward {
       type
       amount
@@ -71,7 +73,9 @@ query {
     id
     eventType
     count
-    conditions
+    conditions {
+      category
+    }
     reward {
       type
       amount
@@ -91,7 +95,7 @@ mutation {
     eventType: "COURSE_COMPLETED"
     count: 5
     conditions: {
-      "category": "MATH"
+      category: "MATH"
     }
     reward: {
       type: "POINTS"
@@ -104,7 +108,9 @@ mutation {
     type
     eventType
     count
-    conditions
+    conditions {
+      category
+    }
     reward {
       type
       amount
@@ -122,6 +128,9 @@ mutation {
     id: "rule-001"
     input: {
       enabled: false
+      conditions: {
+        category: "SCIENCE"
+      }
       reward: {
         type: "POINTS"
         amount: 200
@@ -133,7 +142,9 @@ mutation {
     type
     eventType
     count
-    conditions
+    conditions {
+      category
+    }
     reward {
       type
       amount
@@ -150,9 +161,12 @@ mutation {
 - `id`: Unique identifier
 - `eventType`: Type of event to match
 - `count`: Required count for milestone rules
-- `conditions`: JSON object with matching conditions
+- `conditions`: Structured conditions object with category field
 - `reward`: Reward configuration
 - `enabled`: Whether the rule is active
+
+#### RuleConditions
+- `category`: Category to match against event data
 
 #### Reward
 - `type`: Reward type (e.g., `POINTS`, `BADGE`)

--- a/reward-processor/cmd/api/main.go
+++ b/reward-processor/cmd/api/main.go
@@ -27,10 +27,25 @@ func getPort() string {
 	return defaultPort
 }
 
+func getEnv(key, defaultValue string) string {
+	if value, exists := os.LookupEnv(key); exists {
+		return value
+	}
+	return defaultValue
+}
+
 func main() {
 	// Initialize logger
+	if err := logger.Initialize(logger.Config{
+		Level:      getEnv("LOG_LEVEL", "info"),
+		Production: getEnv("ENV", "development") == "production",
+	}); err != nil {
+		panic("failed to initialize logger: " + err.Error())
+	}
+
+	defer logger.Sync()
+
 	log := logger.Get()
-	defer log.Sync()
 
 	// Create context that listens for the interrupt signal from the OS
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)

--- a/reward-processor/go.mod
+++ b/reward-processor/go.mod
@@ -7,6 +7,7 @@ require go.uber.org/zap v1.27.0
 require (
 	github.com/99designs/gqlgen v0.17.74
 	github.com/IBM/sarama v1.45.2
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/mux v1.8.1
 	github.com/stretchr/testify v1.10.0
 	github.com/vektah/gqlparser/v2 v2.5.27
@@ -22,7 +23,6 @@ require (
 	github.com/eapache/queue v1.1.0 // indirect
 	github.com/go-viper/mapstructure/v2 v2.2.1 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect

--- a/reward-processor/go.mod
+++ b/reward-processor/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475 // indirect
 	github.com/rogpeppe/go-internal v1.14.1 // indirect
 	github.com/sosodev/duration v1.3.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/crypto v0.39.0 // indirect
 	golang.org/x/net v0.41.0 // indirect

--- a/reward-processor/go.sum
+++ b/reward-processor/go.sum
@@ -91,6 +91,8 @@ github.com/sosodev/duration v1.3.1/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERA
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/reward-processor/graph/generated/generated.go
+++ b/reward-processor/graph/generated/generated.go
@@ -333,8 +333,13 @@ type Rule {
   enabled: Boolean!
 }
 
+enum RewardType {
+  BADGE
+  POINTS
+}
+
 type Reward {
-  type: String!
+  type: RewardType!
   amount: Int
   description: String!
 }
@@ -356,7 +361,7 @@ input UpdateRuleInput {
 }
 
 input RewardInput {
-  type: String!
+  type: RewardType!
   amount: Int
   description: String!
 }
@@ -1044,9 +1049,9 @@ func (ec *executionContext) _Reward_type(ctx context.Context, field graphql.Coll
 		}
 		return graphql.Null
 	}
-	res := resTmp.(string)
+	res := resTmp.(model.RewardType)
 	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
+	return ec.marshalNRewardType2githubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRewardType(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Reward_type(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1056,7 +1061,7 @@ func (ec *executionContext) fieldContext_Reward_type(_ context.Context, field gr
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
+			return nil, errors.New("field of type RewardType does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3435,7 +3440,7 @@ func (ec *executionContext) unmarshalInputRewardInput(ctx context.Context, obj a
 		switch k {
 		case "type":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
-			data, err := ec.unmarshalNString2string(ctx, v)
+			data, err := ec.unmarshalNRewardType2githubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRewardType(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -4159,6 +4164,16 @@ func (ec *executionContext) marshalNReward2ᚖgithubᚗcomᚋalexandredsaᚋlear
 func (ec *executionContext) unmarshalNRewardInput2ᚖgithubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRewardInput(ctx context.Context, v any) (*model.RewardInput, error) {
 	res, err := ec.unmarshalInputRewardInput(ctx, v)
 	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) unmarshalNRewardType2githubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRewardType(ctx context.Context, v any) (model.RewardType, error) {
+	var res model.RewardType
+	err := res.UnmarshalGQL(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNRewardType2githubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRewardType(ctx context.Context, sel ast.SelectionSet, v model.RewardType) graphql.Marshaler {
+	return v
 }
 
 func (ec *executionContext) marshalNRule2githubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRule(ctx context.Context, sel ast.SelectionSet, v model.Rule) graphql.Marshaler {

--- a/reward-processor/graph/generated/generated.go
+++ b/reward-processor/graph/generated/generated.go
@@ -69,7 +69,6 @@ type ComplexityRoot struct {
 		EventType  func(childComplexity int) int
 		ID         func(childComplexity int) int
 		Reward     func(childComplexity int) int
-		Type       func(childComplexity int) int
 	}
 }
 
@@ -207,13 +206,6 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Rule.Reward(childComplexity), true
 
-	case "Rule.type":
-		if e.complexity.Rule.Type == nil {
-			break
-		}
-
-		return e.complexity.Rule.Type(childComplexity), true
-
 	}
 	return 0, false
 }
@@ -334,7 +326,6 @@ type Mutation {
 
 type Rule {
   id: ID!
-  type: String!
   eventType: String!
   count: Int
   conditions: JSON
@@ -349,7 +340,6 @@ type Reward {
 }
 
 input CreateRuleInput {
-  type: String!
   eventType: String!
   count: Int
   conditions: JSON
@@ -358,7 +348,6 @@ input CreateRuleInput {
 }
 
 input UpdateRuleInput {
-  type: String
   eventType: String
   count: Int
   conditions: JSON
@@ -677,8 +666,6 @@ func (ec *executionContext) fieldContext_Mutation_createRule(ctx context.Context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Rule_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Rule_type(ctx, field)
 			case "eventType":
 				return ec.fieldContext_Rule_eventType(ctx, field)
 			case "count":
@@ -748,8 +735,6 @@ func (ec *executionContext) fieldContext_Mutation_updateRule(ctx context.Context
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Rule_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Rule_type(ctx, field)
 			case "eventType":
 				return ec.fieldContext_Rule_eventType(ctx, field)
 			case "count":
@@ -819,8 +804,6 @@ func (ec *executionContext) fieldContext_Query_rules(_ context.Context, field gr
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Rule_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Rule_type(ctx, field)
 			case "eventType":
 				return ec.fieldContext_Rule_eventType(ctx, field)
 			case "count":
@@ -876,8 +859,6 @@ func (ec *executionContext) fieldContext_Query_rule(ctx context.Context, field g
 			switch field.Name {
 			case "id":
 				return ec.fieldContext_Rule_id(ctx, field)
-			case "type":
-				return ec.fieldContext_Rule_type(ctx, field)
 			case "eventType":
 				return ec.fieldContext_Rule_eventType(ctx, field)
 			case "count":
@@ -1205,50 +1186,6 @@ func (ec *executionContext) fieldContext_Rule_id(_ context.Context, field graphq
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type ID does not have child fields")
-		},
-	}
-	return fc, nil
-}
-
-func (ec *executionContext) _Rule_type(ctx context.Context, field graphql.CollectedField, obj *model.Rule) (ret graphql.Marshaler) {
-	fc, err := ec.fieldContext_Rule_type(ctx, field)
-	if err != nil {
-		return graphql.Null
-	}
-	ctx = graphql.WithFieldContext(ctx, fc)
-	defer func() {
-		if r := recover(); r != nil {
-			ec.Error(ctx, ec.Recover(ctx, r))
-			ret = graphql.Null
-		}
-	}()
-	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
-		ctx = rctx // use context from middleware stack in children
-		return obj.Type, nil
-	})
-	if err != nil {
-		ec.Error(ctx, err)
-		return graphql.Null
-	}
-	if resTmp == nil {
-		if !graphql.HasFieldError(ctx, fc) {
-			ec.Errorf(ctx, "must not be null")
-		}
-		return graphql.Null
-	}
-	res := resTmp.(string)
-	fc.Result = res
-	return ec.marshalNString2string(ctx, field.Selections, res)
-}
-
-func (ec *executionContext) fieldContext_Rule_type(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
-	fc = &graphql.FieldContext{
-		Object:     "Rule",
-		Field:      field,
-		IsMethod:   false,
-		IsResolver: false,
-		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3434,20 +3371,13 @@ func (ec *executionContext) unmarshalInputCreateRuleInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type", "eventType", "count", "conditions", "reward", "enabled"}
+	fieldsInOrder := [...]string{"eventType", "count", "conditions", "reward", "enabled"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "type":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
-			data, err := ec.unmarshalNString2string(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Type = data
 		case "eventType":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("eventType"))
 			data, err := ec.unmarshalNString2string(ctx, v)
@@ -3537,20 +3467,13 @@ func (ec *executionContext) unmarshalInputUpdateRuleInput(ctx context.Context, o
 		asMap[k] = v
 	}
 
-	fieldsInOrder := [...]string{"type", "eventType", "count", "conditions", "reward", "enabled"}
+	fieldsInOrder := [...]string{"eventType", "count", "conditions", "reward", "enabled"}
 	for _, k := range fieldsInOrder {
 		v, ok := asMap[k]
 		if !ok {
 			continue
 		}
 		switch k {
-		case "type":
-			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("type"))
-			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
-			if err != nil {
-				return it, err
-			}
-			it.Type = data
 		case "eventType":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("eventType"))
 			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
@@ -3806,11 +3729,6 @@ func (ec *executionContext) _Rule(ctx context.Context, sel ast.SelectionSet, obj
 			out.Values[i] = graphql.MarshalString("Rule")
 		case "id":
 			out.Values[i] = ec._Rule_id(ctx, field, obj)
-			if out.Values[i] == graphql.Null {
-				out.Invalids++
-			}
-		case "type":
-			out.Values[i] = ec._Rule_type(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}

--- a/reward-processor/graph/generated/generated.go
+++ b/reward-processor/graph/generated/generated.go
@@ -70,6 +70,10 @@ type ComplexityRoot struct {
 		ID         func(childComplexity int) int
 		Reward     func(childComplexity int) int
 	}
+
+	RuleConditions struct {
+		Category func(childComplexity int) int
+	}
 }
 
 type MutationResolver interface {
@@ -206,6 +210,13 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.complexity.Rule.Reward(childComplexity), true
 
+	case "RuleConditions.category":
+		if e.complexity.RuleConditions.Category == nil {
+			break
+		}
+
+		return e.complexity.RuleConditions.Category(childComplexity), true
+
 	}
 	return 0, false
 }
@@ -216,6 +227,7 @@ func (e *executableSchema) Exec(ctx context.Context) graphql.ResponseHandler {
 	inputUnmarshalMap := graphql.BuildUnmarshalerMap(
 		ec.unmarshalInputCreateRuleInput,
 		ec.unmarshalInputRewardInput,
+		ec.unmarshalInputRuleConditionsInput,
 		ec.unmarshalInputUpdateRuleInput,
 	)
 	first := true
@@ -328,9 +340,13 @@ type Rule {
   id: ID!
   eventType: String!
   count: Int
-  conditions: JSON
+  conditions: RuleConditions
   reward: Reward!
   enabled: Boolean!
+}
+
+type RuleConditions {
+  category: String
 }
 
 enum RewardType {
@@ -347,7 +363,7 @@ type Reward {
 input CreateRuleInput {
   eventType: String!
   count: Int
-  conditions: JSON
+  conditions: RuleConditionsInput
   reward: RewardInput!
   enabled: Boolean!
 }
@@ -355,7 +371,7 @@ input CreateRuleInput {
 input UpdateRuleInput {
   eventType: String
   count: Int
-  conditions: JSON
+  conditions: RuleConditionsInput
   reward: RewardInput
   enabled: Boolean
 }
@@ -364,6 +380,10 @@ input RewardInput {
   type: RewardType!
   amount: Int
   description: String!
+}
+
+input RuleConditionsInput {
+  category: String
 }
 
 scalar JSON
@@ -1304,9 +1324,9 @@ func (ec *executionContext) _Rule_conditions(ctx context.Context, field graphql.
 	if resTmp == nil {
 		return graphql.Null
 	}
-	res := resTmp.(*string)
+	res := resTmp.(*model.RuleConditions)
 	fc.Result = res
-	return ec.marshalOJSON2ᚖstring(ctx, field.Selections, res)
+	return ec.marshalORuleConditions2ᚖgithubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRuleConditions(ctx, field.Selections, res)
 }
 
 func (ec *executionContext) fieldContext_Rule_conditions(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
@@ -1316,7 +1336,11 @@ func (ec *executionContext) fieldContext_Rule_conditions(_ context.Context, fiel
 		IsMethod:   false,
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
-			return nil, errors.New("field of type JSON does not have child fields")
+			switch field.Name {
+			case "category":
+				return ec.fieldContext_RuleConditions_category(ctx, field)
+			}
+			return nil, fmt.Errorf("no field named %q was found under type RuleConditions", field.Name)
 		},
 	}
 	return fc, nil
@@ -1413,6 +1437,47 @@ func (ec *executionContext) fieldContext_Rule_enabled(_ context.Context, field g
 		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return nil, errors.New("field of type Boolean does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _RuleConditions_category(ctx context.Context, field graphql.CollectedField, obj *model.RuleConditions) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_RuleConditions_category(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (any, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.Category, nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		return graphql.Null
+	}
+	res := resTmp.(*string)
+	fc.Result = res
+	return ec.marshalOString2ᚖstring(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_RuleConditions_category(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "RuleConditions",
+		Field:      field,
+		IsMethod:   false,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type String does not have child fields")
 		},
 	}
 	return fc, nil
@@ -3399,7 +3464,7 @@ func (ec *executionContext) unmarshalInputCreateRuleInput(ctx context.Context, o
 			it.Count = data
 		case "conditions":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("conditions"))
-			data, err := ec.unmarshalOJSON2ᚖstring(ctx, v)
+			data, err := ec.unmarshalORuleConditionsInput2ᚖgithubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRuleConditionsInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -3465,6 +3530,33 @@ func (ec *executionContext) unmarshalInputRewardInput(ctx context.Context, obj a
 	return it, nil
 }
 
+func (ec *executionContext) unmarshalInputRuleConditionsInput(ctx context.Context, obj any) (model.RuleConditionsInput, error) {
+	var it model.RuleConditionsInput
+	asMap := map[string]any{}
+	for k, v := range obj.(map[string]any) {
+		asMap[k] = v
+	}
+
+	fieldsInOrder := [...]string{"category"}
+	for _, k := range fieldsInOrder {
+		v, ok := asMap[k]
+		if !ok {
+			continue
+		}
+		switch k {
+		case "category":
+			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("category"))
+			data, err := ec.unmarshalOString2ᚖstring(ctx, v)
+			if err != nil {
+				return it, err
+			}
+			it.Category = data
+		}
+	}
+
+	return it, nil
+}
+
 func (ec *executionContext) unmarshalInputUpdateRuleInput(ctx context.Context, obj any) (model.UpdateRuleInput, error) {
 	var it model.UpdateRuleInput
 	asMap := map[string]any{}
@@ -3495,7 +3587,7 @@ func (ec *executionContext) unmarshalInputUpdateRuleInput(ctx context.Context, o
 			it.Count = data
 		case "conditions":
 			ctx := graphql.WithPathContext(ctx, graphql.NewPathWithField("conditions"))
-			data, err := ec.unmarshalOJSON2ᚖstring(ctx, v)
+			data, err := ec.unmarshalORuleConditionsInput2ᚖgithubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRuleConditionsInput(ctx, v)
 			if err != nil {
 				return it, err
 			}
@@ -3756,6 +3848,42 @@ func (ec *executionContext) _Rule(ctx context.Context, sel ast.SelectionSet, obj
 			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.deferred, int32(len(deferred)))
+
+	for label, dfs := range deferred {
+		ec.processDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var ruleConditionsImplementors = []string{"RuleConditions"}
+
+func (ec *executionContext) _RuleConditions(ctx context.Context, sel ast.SelectionSet, obj *model.RuleConditions) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, ruleConditionsImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("RuleConditions")
+		case "category":
+			out.Values[i] = ec._RuleConditions_category(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -4556,24 +4684,6 @@ func (ec *executionContext) marshalOInt2ᚖint(ctx context.Context, sel ast.Sele
 	return res
 }
 
-func (ec *executionContext) unmarshalOJSON2ᚖstring(ctx context.Context, v any) (*string, error) {
-	if v == nil {
-		return nil, nil
-	}
-	res, err := graphql.UnmarshalString(v)
-	return &res, graphql.ErrorOnPath(ctx, err)
-}
-
-func (ec *executionContext) marshalOJSON2ᚖstring(ctx context.Context, sel ast.SelectionSet, v *string) graphql.Marshaler {
-	if v == nil {
-		return graphql.Null
-	}
-	_ = sel
-	_ = ctx
-	res := graphql.MarshalString(*v)
-	return res
-}
-
 func (ec *executionContext) unmarshalORewardInput2ᚖgithubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRewardInput(ctx context.Context, v any) (*model.RewardInput, error) {
 	if v == nil {
 		return nil, nil
@@ -4587,6 +4697,21 @@ func (ec *executionContext) marshalORule2ᚖgithubᚗcomᚋalexandredsaᚋlearni
 		return graphql.Null
 	}
 	return ec._Rule(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalORuleConditions2ᚖgithubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRuleConditions(ctx context.Context, sel ast.SelectionSet, v *model.RuleConditions) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._RuleConditions(ctx, sel, v)
+}
+
+func (ec *executionContext) unmarshalORuleConditionsInput2ᚖgithubᚗcomᚋalexandredsaᚋlearningᚑrewardsᚋrewardᚑprocessorᚋgraphᚋmodelᚐRuleConditionsInput(ctx context.Context, v any) (*model.RuleConditionsInput, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := ec.unmarshalInputRuleConditionsInput(ctx, v)
+	return &res, graphql.ErrorOnPath(ctx, err)
 }
 
 func (ec *executionContext) unmarshalOString2ᚖstring(ctx context.Context, v any) (*string, error) {

--- a/reward-processor/graph/model/models_gen.go
+++ b/reward-processor/graph/model/models_gen.go
@@ -3,7 +3,6 @@
 package model
 
 type CreateRuleInput struct {
-	Type       string       `json:"type"`
 	EventType  string       `json:"eventType"`
 	Count      *int         `json:"count,omitempty"`
 	Conditions *string      `json:"conditions,omitempty"`
@@ -31,7 +30,6 @@ type RewardInput struct {
 
 type Rule struct {
 	ID         string  `json:"id"`
-	Type       string  `json:"type"`
 	EventType  string  `json:"eventType"`
 	Count      *int    `json:"count,omitempty"`
 	Conditions *string `json:"conditions,omitempty"`
@@ -40,7 +38,6 @@ type Rule struct {
 }
 
 type UpdateRuleInput struct {
-	Type       *string      `json:"type,omitempty"`
 	EventType  *string      `json:"eventType,omitempty"`
 	Count      *int         `json:"count,omitempty"`
 	Conditions *string      `json:"conditions,omitempty"`

--- a/reward-processor/graph/model/models_gen.go
+++ b/reward-processor/graph/model/models_gen.go
@@ -10,11 +10,11 @@ import (
 )
 
 type CreateRuleInput struct {
-	EventType  string       `json:"eventType"`
-	Count      *int         `json:"count,omitempty"`
-	Conditions *string      `json:"conditions,omitempty"`
-	Reward     *RewardInput `json:"reward"`
-	Enabled    bool         `json:"enabled"`
+	EventType  string               `json:"eventType"`
+	Count      *int                 `json:"count,omitempty"`
+	Conditions *RuleConditionsInput `json:"conditions,omitempty"`
+	Reward     *RewardInput         `json:"reward"`
+	Enabled    bool                 `json:"enabled"`
 }
 
 type Mutation struct {
@@ -36,20 +36,28 @@ type RewardInput struct {
 }
 
 type Rule struct {
-	ID         string  `json:"id"`
-	EventType  string  `json:"eventType"`
-	Count      *int    `json:"count,omitempty"`
-	Conditions *string `json:"conditions,omitempty"`
-	Reward     *Reward `json:"reward"`
-	Enabled    bool    `json:"enabled"`
+	ID         string          `json:"id"`
+	EventType  string          `json:"eventType"`
+	Count      *int            `json:"count,omitempty"`
+	Conditions *RuleConditions `json:"conditions,omitempty"`
+	Reward     *Reward         `json:"reward"`
+	Enabled    bool            `json:"enabled"`
+}
+
+type RuleConditions struct {
+	Category *string `json:"category,omitempty"`
+}
+
+type RuleConditionsInput struct {
+	Category *string `json:"category,omitempty"`
 }
 
 type UpdateRuleInput struct {
-	EventType  *string      `json:"eventType,omitempty"`
-	Count      *int         `json:"count,omitempty"`
-	Conditions *string      `json:"conditions,omitempty"`
-	Reward     *RewardInput `json:"reward,omitempty"`
-	Enabled    *bool        `json:"enabled,omitempty"`
+	EventType  *string              `json:"eventType,omitempty"`
+	Count      *int                 `json:"count,omitempty"`
+	Conditions *RuleConditionsInput `json:"conditions,omitempty"`
+	Reward     *RewardInput         `json:"reward,omitempty"`
+	Enabled    *bool                `json:"enabled,omitempty"`
 }
 
 type RewardType string

--- a/reward-processor/graph/resolver/helpers.go
+++ b/reward-processor/graph/resolver/helpers.go
@@ -28,7 +28,6 @@ func convertToGraphQLRule(rule *models.Rule) *model.Rule {
 	condStr := string(conditionsJSON)
 	return &model.Rule{
 		ID:         rule.ID,
-		Type:       string(rule.Type),
 		EventType:  rule.EventType,
 		Count:      countPtr,
 		Conditions: &condStr,

--- a/reward-processor/graph/resolver/helpers.go
+++ b/reward-processor/graph/resolver/helpers.go
@@ -1,16 +1,15 @@
 package resolver
 
 import (
-	"encoding/json"
-
 	"github.com/alexandredsa/learning-rewards/reward-processor/graph/model"
 	"github.com/alexandredsa/learning-rewards/reward-processor/pkg/models"
 )
 
-func convertToGraphQLRule(rule *models.Rule) *model.Rule {
-	// Convert conditions to JSON string
-	conditionsJSON, _ := json.Marshal(rule.Conditions)
+const (
+	minCountValue = 1
+)
 
+func ConvertToGraphQLRule(rule *models.Rule) *model.Rule {
 	// Convert count to pointer
 	var countPtr *int
 	if rule.Count > 0 {
@@ -25,17 +24,98 @@ func convertToGraphQLRule(rule *models.Rule) *model.Rule {
 		amountPtr = &amount
 	}
 
-	condStr := string(conditionsJSON)
+	var conditions *model.RuleConditions
+	if rule.Conditions != nil {
+		if rule.Conditions.Category != nil {
+			conditions = &model.RuleConditions{
+				Category: rule.Conditions.Category,
+			}
+		}
+	}
+
 	return &model.Rule{
 		ID:         rule.ID,
 		EventType:  rule.EventType,
 		Count:      countPtr,
-		Conditions: &condStr,
+		Conditions: conditions,
 		Reward: &model.Reward{
 			Type:        model.RewardType(rule.Reward.Type),
 			Amount:      amountPtr,
 			Description: rule.Reward.Description,
 		},
 		Enabled: rule.Enabled,
+	}
+}
+
+func ConvertGraphQLRuleToModel(rule interface{}) *models.Rule {
+	switch r := rule.(type) {
+	case *model.CreateRuleInput:
+		// Convert count from pointer to value
+		count := 0
+		if r.Count != nil {
+			count = *r.Count
+		} else {
+			count = minCountValue
+		}
+
+		// Convert conditions
+		var conditions *models.RuleConditions
+		if r.Conditions != nil && r.Conditions.Category != nil {
+			conditions = &models.RuleConditions{
+				Category: r.Conditions.Category,
+			}
+		}
+
+		// Convert reward amount from pointer to value
+		rewardAmount := 0
+		if r.Reward.Amount != nil {
+			rewardAmount = *r.Reward.Amount
+		}
+
+		return &models.Rule{
+			EventType:  r.EventType,
+			Count:      count,
+			Conditions: conditions,
+			Reward: models.Reward{
+				Type:        models.RewardType(r.Reward.Type),
+				Amount:      rewardAmount,
+				Description: r.Reward.Description,
+			},
+			Enabled: r.Enabled,
+		}
+
+	case *model.UpdateRuleInput:
+		rule := &models.Rule{}
+
+		if r.EventType != nil {
+			rule.EventType = *r.EventType
+		}
+		if r.Count != nil {
+			rule.Count = *r.Count
+		}
+		if r.Conditions != nil && r.Conditions.Category != nil {
+			rule.Conditions = &models.RuleConditions{
+				Category: r.Conditions.Category,
+			}
+		}
+		if r.Reward != nil {
+			if r.Reward.Type != "" {
+				rule.Reward.Type = models.RewardType(r.Reward.Type)
+			}
+			if r.Reward.Amount != nil {
+				rule.Reward.Amount = *r.Reward.Amount
+			}
+			if r.Reward.Description != "" {
+				rule.Reward.Description = r.Reward.Description
+			}
+		}
+		if r.Enabled != nil {
+			rule.Enabled = *r.Enabled
+		}
+
+		return rule
+
+	default:
+		return nil
 	}
 }

--- a/reward-processor/graph/resolver/helpers.go
+++ b/reward-processor/graph/resolver/helpers.go
@@ -32,7 +32,7 @@ func convertToGraphQLRule(rule *models.Rule) *model.Rule {
 		Count:      countPtr,
 		Conditions: &condStr,
 		Reward: &model.Reward{
-			Type:        string(rule.Reward.Type),
+			Type:        model.RewardType(rule.Reward.Type),
 			Amount:      amountPtr,
 			Description: rule.Reward.Description,
 		},

--- a/reward-processor/graph/resolver/helpers.go
+++ b/reward-processor/graph/resolver/helpers.go
@@ -25,11 +25,9 @@ func ConvertToGraphQLRule(rule *models.Rule) *model.Rule {
 	}
 
 	var conditions *model.RuleConditions
-	if rule.Conditions != nil {
-		if rule.Conditions.Category != nil {
-			conditions = &model.RuleConditions{
-				Category: rule.Conditions.Category,
-			}
+	if rule.ConditionsCategory != nil {
+		conditions = &model.RuleConditions{
+			Category: rule.ConditionsCategory,
 		}
 	}
 
@@ -59,11 +57,9 @@ func ConvertGraphQLRuleToModel(rule interface{}) *models.Rule {
 		}
 
 		// Convert conditions
-		var conditions *models.RuleConditions
+		var conditionsCategory *string
 		if r.Conditions != nil && r.Conditions.Category != nil {
-			conditions = &models.RuleConditions{
-				Category: r.Conditions.Category,
-			}
+			conditionsCategory = r.Conditions.Category
 		}
 
 		// Convert reward amount from pointer to value
@@ -73,9 +69,9 @@ func ConvertGraphQLRuleToModel(rule interface{}) *models.Rule {
 		}
 
 		return &models.Rule{
-			EventType:  r.EventType,
-			Count:      count,
-			Conditions: conditions,
+			EventType:          r.EventType,
+			Count:              count,
+			ConditionsCategory: conditionsCategory,
 			Reward: models.Reward{
 				Type:        models.RewardType(r.Reward.Type),
 				Amount:      rewardAmount,
@@ -94,9 +90,7 @@ func ConvertGraphQLRuleToModel(rule interface{}) *models.Rule {
 			rule.Count = *r.Count
 		}
 		if r.Conditions != nil && r.Conditions.Category != nil {
-			rule.Conditions = &models.RuleConditions{
-				Category: r.Conditions.Category,
-			}
+			rule.ConditionsCategory = r.Conditions.Category
 		}
 		if r.Reward != nil {
 			if r.Reward.Type != "" {

--- a/reward-processor/graph/resolver/resolver.go
+++ b/reward-processor/graph/resolver/resolver.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"github.com/alexandredsa/learning-rewards/reward-processor/internal/repository"
+	"go.uber.org/zap"
 )
 
 // This file will not be regenerated automatically.
@@ -10,11 +11,13 @@ import (
 
 type Resolver struct {
 	RuleRepository repository.RuleRepository
+	Logger         *zap.Logger
 }
 
 // NewResolver creates a new resolver with the required dependencies
-func NewResolver(ruleRepo repository.RuleRepository) *Resolver {
+func NewResolver(ruleRepo repository.RuleRepository, logger *zap.Logger) *Resolver {
 	return &Resolver{
 		RuleRepository: ruleRepo,
+		Logger:         logger,
 	}
 }

--- a/reward-processor/graph/resolver/resolver_test.go
+++ b/reward-processor/graph/resolver/resolver_test.go
@@ -78,11 +78,9 @@ func TestCreateRule(t *testing.T) {
 			name: "create rule with conditions",
 			setupMocks: func(m *MockRuleRepository) {
 				m.On("CreateRule", mock.Anything, &models.Rule{
-					EventType: "COURSE_COMPLETED",
-					Count:     5,
-					Conditions: &models.RuleConditions{
-						Category: ptrString("MATH"),
-					},
+					EventType:          "COURSE_COMPLETED",
+					Count:              5,
+					ConditionsCategory: ptrString("MATH"),
 					Reward: models.Reward{
 						Type:        models.RewardType("POINTS"),
 						Amount:      100,
@@ -174,9 +172,9 @@ func TestUpdateRule(t *testing.T) {
 			name: "update rule conditions",
 			setupMocks: func(m *MockRuleRepository) {
 				existingRule := &models.Rule{
-					ID:         "rule-001",
-					EventType:  "COURSE_COMPLETED",
-					Conditions: &models.RuleConditions{Category: ptrString("MATH")},
+					ID:                 "rule-001",
+					EventType:          "COURSE_COMPLETED",
+					ConditionsCategory: ptrString("MATH"),
 					Reward: models.Reward{
 						Type:        models.RewardType("POINTS"),
 						Amount:      100,
@@ -185,9 +183,9 @@ func TestUpdateRule(t *testing.T) {
 					Enabled: true,
 				}
 				updatedRule := &models.Rule{
-					ID:         "rule-001",
-					EventType:  "COURSE_COMPLETED",
-					Conditions: &models.RuleConditions{Category: ptrString("SCIENCE")},
+					ID:                 "rule-001",
+					EventType:          "COURSE_COMPLETED",
+					ConditionsCategory: ptrString("SCIENCE"),
 					Reward: models.Reward{
 						Type:        models.RewardType("POINTS"),
 						Amount:      100,
@@ -198,7 +196,7 @@ func TestUpdateRule(t *testing.T) {
 
 				m.On("GetRuleByID", mock.Anything, "rule-001").Return(existingRule, nil)
 				m.On("UpdateRule", mock.Anything, "rule-001", mock.MatchedBy(func(rule *models.Rule) bool {
-					return rule.Conditions.Category != nil && *rule.Conditions.Category == "SCIENCE"
+					return rule.ConditionsCategory != nil && *rule.ConditionsCategory == "SCIENCE"
 				})).Return(nil)
 				m.On("GetRuleByID", mock.Anything, "rule-001").Return(updatedRule, nil)
 			},
@@ -237,12 +235,10 @@ func TestConvertToGraphQLRule(t *testing.T) {
 		{
 			name: "convert rule with conditions",
 			input: &models.Rule{
-				ID:        "rule-001",
-				EventType: "COURSE_COMPLETED",
-				Count:     5,
-				Conditions: &models.RuleConditions{
-					Category: ptrString("MATH"),
-				},
+				ID:                 "rule-001",
+				EventType:          "COURSE_COMPLETED",
+				Count:              5,
+				ConditionsCategory: ptrString("MATH"),
 				Reward: models.Reward{
 					Type:        models.RewardType("POINTS"),
 					Amount:      100,

--- a/reward-processor/graph/resolver/resolver_test.go
+++ b/reward-processor/graph/resolver/resolver_test.go
@@ -1,0 +1,308 @@
+package resolver_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alexandredsa/learning-rewards/reward-processor/graph/model"
+	"github.com/alexandredsa/learning-rewards/reward-processor/graph/resolver"
+	"github.com/alexandredsa/learning-rewards/reward-processor/pkg/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/zap"
+)
+
+// MockRuleRepository is a mock implementation of repository.RuleRepository
+type MockRuleRepository struct {
+	mock.Mock
+}
+
+func (m *MockRuleRepository) CreateRule(ctx context.Context, rule *models.Rule) error {
+	args := m.Called(ctx, rule)
+	return args.Error(0)
+}
+
+func (m *MockRuleRepository) UpdateRule(ctx context.Context, id string, rule *models.Rule) error {
+	args := m.Called(ctx, id, rule)
+	return args.Error(0)
+}
+
+func (m *MockRuleRepository) GetRuleByID(ctx context.Context, id string) (*models.Rule, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*models.Rule), args.Error(1)
+}
+
+func (m *MockRuleRepository) GetEnabledRules(ctx context.Context) ([]models.Rule, error) {
+	args := m.Called(ctx)
+	return args.Get(0).([]models.Rule), args.Error(1)
+}
+
+// TestCase represents a test case with setup and assertions
+type TestCase struct {
+	name         string
+	setupMocks   func(*MockRuleRepository)
+	runTest      func(*resolver.Resolver) (interface{}, error)
+	assertResult func(*testing.T, interface{}, error)
+	assertMocks  func(*testing.T, *MockRuleRepository)
+}
+
+func setupTestResolver(t *testing.T) (*resolver.Resolver, *MockRuleRepository) {
+	mockRepo := new(MockRuleRepository)
+	logger, _ := zap.NewDevelopment()
+	resolver := resolver.NewResolver(mockRepo, logger)
+	return resolver, mockRepo
+}
+
+func runTestCase(t *testing.T, tc TestCase) {
+	resolver, mockRepo := setupTestResolver(t)
+
+	// Setup mocks
+	tc.setupMocks(mockRepo)
+
+	// Run test
+	result, err := tc.runTest(resolver)
+
+	// Assert results
+	tc.assertResult(t, result, err)
+
+	// Assert mock expectations
+	tc.assertMocks(t, mockRepo)
+}
+
+func TestCreateRule(t *testing.T) {
+	tests := []TestCase{
+		{
+			name: "create rule with conditions",
+			setupMocks: func(m *MockRuleRepository) {
+				m.On("CreateRule", mock.Anything, &models.Rule{
+					EventType: "COURSE_COMPLETED",
+					Count:     5,
+					Conditions: &models.RuleConditions{
+						Category: ptrString("MATH"),
+					},
+					Reward: models.Reward{
+						Type:        models.RewardType("POINTS"),
+						Amount:      100,
+						Description: "Completed 5 math courses",
+					},
+					Enabled: true,
+				}).Return(nil)
+			},
+			runTest: func(r *resolver.Resolver) (interface{}, error) {
+				return r.Mutation().CreateRule(context.Background(), model.CreateRuleInput{
+					EventType: "COURSE_COMPLETED",
+					Count:     ptrInt(5),
+					Conditions: &model.RuleConditionsInput{
+						Category: ptrString("MATH"),
+					},
+					Reward: &model.RewardInput{
+						Type:        model.RewardType("POINTS"),
+						Amount:      ptrInt(100),
+						Description: "Completed 5 math courses",
+					},
+					Enabled: true,
+				})
+			},
+			assertResult: func(t *testing.T, result interface{}, err error) {
+				assert.NoError(t, err)
+				rule := result.(*model.Rule)
+				assert.Equal(t, "COURSE_COMPLETED", rule.EventType)
+				assert.Equal(t, ptrInt(5), rule.Count)
+				assert.Equal(t, ptrString("MATH"), rule.Conditions.Category)
+				assert.Equal(t, model.RewardType("POINTS"), rule.Reward.Type)
+				assert.Equal(t, ptrInt(100), rule.Reward.Amount)
+				assert.Equal(t, "Completed 5 math courses", rule.Reward.Description)
+				assert.True(t, rule.Enabled)
+			},
+			assertMocks: func(t *testing.T, m *MockRuleRepository) {
+				m.AssertExpectations(t)
+			},
+		},
+		{
+			name: "create rule without conditions (count should default to '1')",
+			setupMocks: func(m *MockRuleRepository) {
+				m.On("CreateRule", mock.Anything, &models.Rule{
+					EventType: "COURSE_COMPLETED",
+					Count:     1,
+					Reward: models.Reward{
+						Type:        models.RewardType("BADGE"),
+						Description: "Completed a course",
+					},
+					Enabled: true,
+				}).Return(nil)
+			},
+			runTest: func(r *resolver.Resolver) (interface{}, error) {
+				return r.Mutation().CreateRule(context.Background(), model.CreateRuleInput{
+					EventType: "COURSE_COMPLETED",
+					Reward: &model.RewardInput{
+						Type:        model.RewardType("BADGE"),
+						Description: "Completed a course",
+					},
+					Enabled: true,
+				})
+			},
+			assertResult: func(t *testing.T, result interface{}, err error) {
+				assert.NoError(t, err)
+				rule := result.(*model.Rule)
+				assert.Equal(t, "COURSE_COMPLETED", rule.EventType)
+				assert.Equal(t, *rule.Count, 1)
+				assert.Nil(t, rule.Conditions)
+				assert.Equal(t, model.RewardType("BADGE"), rule.Reward.Type)
+				assert.Nil(t, rule.Reward.Amount)
+				assert.Equal(t, "Completed a course", rule.Reward.Description)
+				assert.True(t, rule.Enabled)
+			},
+			assertMocks: func(t *testing.T, m *MockRuleRepository) {
+				m.AssertExpectations(t)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runTestCase(t, tc)
+		})
+	}
+}
+
+func TestUpdateRule(t *testing.T) {
+	tests := []TestCase{
+		{
+			name: "update rule conditions",
+			setupMocks: func(m *MockRuleRepository) {
+				existingRule := &models.Rule{
+					ID:         "rule-001",
+					EventType:  "COURSE_COMPLETED",
+					Conditions: &models.RuleConditions{Category: ptrString("MATH")},
+					Reward: models.Reward{
+						Type:        models.RewardType("POINTS"),
+						Amount:      100,
+						Description: "Math course reward",
+					},
+					Enabled: true,
+				}
+				updatedRule := &models.Rule{
+					ID:         "rule-001",
+					EventType:  "COURSE_COMPLETED",
+					Conditions: &models.RuleConditions{Category: ptrString("SCIENCE")},
+					Reward: models.Reward{
+						Type:        models.RewardType("POINTS"),
+						Amount:      100,
+						Description: "Math course reward",
+					},
+					Enabled: true,
+				}
+
+				m.On("GetRuleByID", mock.Anything, "rule-001").Return(existingRule, nil)
+				m.On("UpdateRule", mock.Anything, "rule-001", mock.MatchedBy(func(rule *models.Rule) bool {
+					return rule.Conditions.Category != nil && *rule.Conditions.Category == "SCIENCE"
+				})).Return(nil)
+				m.On("GetRuleByID", mock.Anything, "rule-001").Return(updatedRule, nil)
+			},
+			runTest: func(r *resolver.Resolver) (interface{}, error) {
+				return r.Mutation().UpdateRule(context.Background(), "rule-001", model.UpdateRuleInput{
+					Conditions: &model.RuleConditionsInput{
+						Category: ptrString("SCIENCE"),
+					},
+				})
+			},
+			assertResult: func(t *testing.T, result interface{}, err error) {
+				assert.NoError(t, err)
+				rule := result.(*model.Rule)
+				assert.Equal(t, "rule-001", rule.ID)
+				assert.Equal(t, ptrString("SCIENCE"), rule.Conditions.Category)
+			},
+			assertMocks: func(t *testing.T, m *MockRuleRepository) {
+				m.AssertExpectations(t)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			runTestCase(t, tc)
+		})
+	}
+}
+
+func TestConvertToGraphQLRule(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *models.Rule
+		expected *model.Rule
+	}{
+		{
+			name: "convert rule with conditions",
+			input: &models.Rule{
+				ID:        "rule-001",
+				EventType: "COURSE_COMPLETED",
+				Count:     5,
+				Conditions: &models.RuleConditions{
+					Category: ptrString("MATH"),
+				},
+				Reward: models.Reward{
+					Type:        models.RewardType("POINTS"),
+					Amount:      100,
+					Description: "Math course reward",
+				},
+				Enabled: true,
+			},
+			expected: &model.Rule{
+				ID:        "rule-001",
+				EventType: "COURSE_COMPLETED",
+				Count:     ptrInt(5),
+				Conditions: &model.RuleConditions{
+					Category: ptrString("MATH"),
+				},
+				Reward: &model.Reward{
+					Type:        model.RewardType("POINTS"),
+					Amount:      ptrInt(100),
+					Description: "Math course reward",
+				},
+				Enabled: true,
+			},
+		},
+		{
+			name: "convert rule without conditions",
+			input: &models.Rule{
+				ID:        "rule-002",
+				EventType: "COURSE_COMPLETED",
+				Reward: models.Reward{
+					Type:        models.RewardType("BADGE"),
+					Description: "Course completion badge",
+				},
+				Enabled: true,
+			},
+			expected: &model.Rule{
+				ID:         "rule-002",
+				EventType:  "COURSE_COMPLETED",
+				Conditions: nil,
+				Reward: &model.Reward{
+					Type:        model.RewardType("BADGE"),
+					Description: "Course completion badge",
+				},
+				Enabled: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := resolver.ConvertToGraphQLRule(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// Helper function to create a pointer to an int
+func ptrInt(i int) *int {
+	return &i
+}
+
+// Helper function to create a pointer to a string
+func ptrString(s string) *string {
+	return &s
+}

--- a/reward-processor/graph/resolver/schema.resolvers.go
+++ b/reward-processor/graph/resolver/schema.resolvers.go
@@ -60,8 +60,8 @@ func (r *mutationResolver) UpdateRule(ctx context.Context, id string, input mode
 	if updates.Count > 0 {
 		existingRule.Count = updates.Count
 	}
-	if updates.Conditions != nil {
-		existingRule.Conditions = updates.Conditions
+	if updates.ConditionsCategory != nil {
+		existingRule.ConditionsCategory = updates.ConditionsCategory
 	}
 	if updates.Reward.Type != "" {
 		existingRule.Reward.Type = updates.Reward.Type

--- a/reward-processor/graph/schema.graphqls
+++ b/reward-processor/graph/schema.graphqls
@@ -10,7 +10,6 @@ type Mutation {
 
 type Rule {
   id: ID!
-  type: String!
   eventType: String!
   count: Int
   conditions: JSON
@@ -25,7 +24,6 @@ type Reward {
 }
 
 input CreateRuleInput {
-  type: String!
   eventType: String!
   count: Int
   conditions: JSON
@@ -34,7 +32,6 @@ input CreateRuleInput {
 }
 
 input UpdateRuleInput {
-  type: String
   eventType: String
   count: Int
   conditions: JSON

--- a/reward-processor/graph/schema.graphqls
+++ b/reward-processor/graph/schema.graphqls
@@ -17,8 +17,13 @@ type Rule {
   enabled: Boolean!
 }
 
+enum RewardType {
+  BADGE
+  POINTS
+}
+
 type Reward {
-  type: String!
+  type: RewardType!
   amount: Int
   description: String!
 }
@@ -40,7 +45,7 @@ input UpdateRuleInput {
 }
 
 input RewardInput {
-  type: String!
+  type: RewardType!
   amount: Int
   description: String!
 }

--- a/reward-processor/graph/schema.graphqls
+++ b/reward-processor/graph/schema.graphqls
@@ -12,9 +12,13 @@ type Rule {
   id: ID!
   eventType: String!
   count: Int
-  conditions: JSON
+  conditions: RuleConditions
   reward: Reward!
   enabled: Boolean!
+}
+
+type RuleConditions {
+  category: String
 }
 
 enum RewardType {
@@ -31,7 +35,7 @@ type Reward {
 input CreateRuleInput {
   eventType: String!
   count: Int
-  conditions: JSON
+  conditions: RuleConditionsInput
   reward: RewardInput!
   enabled: Boolean!
 }
@@ -39,7 +43,7 @@ input CreateRuleInput {
 input UpdateRuleInput {
   eventType: String
   count: Int
-  conditions: JSON
+  conditions: RuleConditionsInput
   reward: RewardInput
   enabled: Boolean
 }
@@ -48,6 +52,10 @@ input RewardInput {
   type: RewardType!
   amount: Int
   description: String!
+}
+
+input RuleConditionsInput {
+  category: String!
 }
 
 scalar JSON

--- a/reward-processor/internal/database/seed/rules.go
+++ b/reward-processor/internal/database/seed/rules.go
@@ -41,12 +41,10 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 	// Define initial rules
 	initialRules := []models.Rule{
 		{
-			ID:        "rule-001",
-			EventType: "COURSE_COMPLETED",
-			Conditions: &models.RuleConditions{
-				Category: &categoryMath,
-			},
-			Count: 1,
+			ID:                 "rule-001",
+			EventType:          "COURSE_COMPLETED",
+			ConditionsCategory: &categoryMath,
+			Count:              1,
 			Reward: models.Reward{
 				Type:        models.BadgeReward,
 				Description: "Finished a Math course",
@@ -54,12 +52,10 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 			Enabled: true,
 		},
 		{
-			ID:        "rule-002",
-			EventType: "COURSE_COMPLETED",
-			Count:     5,
-			Conditions: &models.RuleConditions{
-				Category: &categoryMath,
-			},
+			ID:                 "rule-002",
+			EventType:          "COURSE_COMPLETED",
+			Count:              5,
+			ConditionsCategory: &categoryMath,
 			Reward: models.Reward{
 				Type:        models.PointsReward,
 				Amount:      100,
@@ -90,12 +86,10 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 			Enabled: true,
 		},
 		{
-			ID:        "rule-005",
-			EventType: "COURSE_COMPLETED",
-			Count:     1,
-			Conditions: &models.RuleConditions{
-				Category: &categoryProgramming,
-			},
+			ID:                 "rule-005",
+			EventType:          "COURSE_COMPLETED",
+			Count:              1,
+			ConditionsCategory: &categoryProgramming,
 			Reward: models.Reward{
 				Type:        models.BadgeReward,
 				Description: "Finished a Programming course",
@@ -103,12 +97,10 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 			Enabled: true,
 		},
 		{
-			ID:        "rule-006",
-			EventType: "COURSE_COMPLETED",
-			Count:     5,
-			Conditions: &models.RuleConditions{
-				Category: &categoryProgramming,
-			},
+			ID:                 "rule-006",
+			EventType:          "COURSE_COMPLETED",
+			Count:              5,
+			ConditionsCategory: &categoryProgramming,
 			Reward: models.Reward{
 				Type:        models.PointsReward,
 				Amount:      150,

--- a/reward-processor/internal/database/seed/rules.go
+++ b/reward-processor/internal/database/seed/rules.go
@@ -33,13 +33,18 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 		return nil
 	}
 
+	var (
+		categoryMath        string = "MATH"
+		categoryProgramming string = "PROGRAMMING"
+	)
+
 	// Define initial rules
 	initialRules := []models.Rule{
 		{
 			ID:        "rule-001",
 			EventType: "COURSE_COMPLETED",
-			Conditions: map[string]string{
-				"category": "MATH",
+			Conditions: &models.RuleConditions{
+				Category: &categoryMath,
 			},
 			Count: 1,
 			Reward: models.Reward{
@@ -52,8 +57,8 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 			ID:        "rule-002",
 			EventType: "COURSE_COMPLETED",
 			Count:     5,
-			Conditions: map[string]string{
-				"category": "MATH",
+			Conditions: &models.RuleConditions{
+				Category: &categoryMath,
 			},
 			Reward: models.Reward{
 				Type:        models.PointsReward,
@@ -63,10 +68,9 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 			Enabled: true,
 		},
 		{
-			ID:         "rule-003",
-			EventType:  "COURSE_COMPLETED",
-			Count:      30,
-			Conditions: map[string]string{},
+			ID:        "rule-003",
+			EventType: "COURSE_COMPLETED",
+			Count:     30,
 			Reward: models.Reward{
 				Type:        models.PointsReward,
 				Amount:      30,
@@ -75,10 +79,9 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 			Enabled: true,
 		},
 		{
-			ID:         "rule-004",
-			EventType:  "CHAPTER_COMPLETED",
-			Count:      10,
-			Conditions: map[string]string{},
+			ID:        "rule-004",
+			EventType: "CHAPTER_COMPLETED",
+			Count:     10,
 			Reward: models.Reward{
 				Type:        models.PointsReward,
 				Amount:      10,
@@ -90,8 +93,8 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 			ID:        "rule-005",
 			EventType: "COURSE_COMPLETED",
 			Count:     1,
-			Conditions: map[string]string{
-				"category": "PROGRAMMING",
+			Conditions: &models.RuleConditions{
+				Category: &categoryProgramming,
 			},
 			Reward: models.Reward{
 				Type:        models.BadgeReward,
@@ -103,8 +106,8 @@ func SeedRules(ctx context.Context, db *gorm.DB, log *zap.Logger) error {
 			ID:        "rule-006",
 			EventType: "COURSE_COMPLETED",
 			Count:     5,
-			Conditions: map[string]string{
-				"category": "PROGRAMMING",
+			Conditions: &models.RuleConditions{
+				Category: &categoryProgramming,
 			},
 			Reward: models.Reward{
 				Type:        models.PointsReward,

--- a/reward-processor/internal/rules/engine.go
+++ b/reward-processor/internal/rules/engine.go
@@ -69,11 +69,11 @@ func (e *Engine) EvaluateEvent(ctx context.Context, event models.UserEvent) ([]m
 		}
 
 		// Check conditions
-		if !e.matchesConditions(event, rule.Conditions) {
+		if !e.matchesConditions(event, rule) {
 			e.logger.Debug("Rule conditions not met",
 				zap.String("rule_id", rule.ID),
 				zap.String("user_id", event.UserID),
-				zap.Any("conditions", rule.Conditions),
+				zap.Any("conditions", rule.ConditionsCategory),
 				zap.Any("event_data", event))
 			continue
 		}
@@ -85,8 +85,8 @@ func (e *Engine) EvaluateEvent(ctx context.Context, event models.UserEvent) ([]m
 
 		var ruleCategory string
 
-		if rule.Conditions != nil && rule.Conditions.Category != nil {
-			ruleCategory = *rule.Conditions.Category
+		if rule.ConditionsCategory != nil {
+			ruleCategory = *rule.ConditionsCategory
 		}
 
 		// Get the appropriate count based on rule type
@@ -134,15 +134,11 @@ func (e *Engine) EvaluateEvent(ctx context.Context, event models.UserEvent) ([]m
 }
 
 // matchesConditions checks if an event matches all conditions in a rule
-func (e *Engine) matchesConditions(event models.UserEvent, conditions *models.RuleConditions) bool {
-	if conditions == nil {
+func (e *Engine) matchesConditions(event models.UserEvent, rule models.Rule) bool {
+	if rule.ConditionsCategory == nil {
 		return true
 	}
-
-	if conditions.Category != nil {
-		return *conditions.Category == event.Category
-	}
-	return true
+	return *rule.ConditionsCategory == event.Category
 }
 
 // GetMilestoneCount returns the current count for a user's milestone

--- a/reward-processor/internal/rules/engine.go
+++ b/reward-processor/internal/rules/engine.go
@@ -80,8 +80,8 @@ func (e *Engine) EvaluateEvent(ctx context.Context, event models.UserEvent) ([]m
 
 		e.logger.Debug("Rule conditions met, evaluating rule",
 			zap.String("rule_id", rule.ID),
-			zap.String("rule_type", string(rule.Type)),
-			zap.String("user_id", event.UserID))
+			zap.String("user_id", event.UserID),
+		)
 
 		// Get the appropriate count based on rule type
 		ruleCategory := rule.Conditions["category"]

--- a/reward-processor/internal/rules/engine_test.go
+++ b/reward-processor/internal/rules/engine_test.go
@@ -36,8 +36,9 @@ func TestEvaluateEvent_SingleEventRule(t *testing.T) {
 	rule := models.Rule{
 		ID:        "rule-001",
 		EventType: "COURSE_COMPLETED",
-		Conditions: map[string]string{
-			"category": "MATH",
+		Count:     1,
+		Conditions: &models.RuleConditions{
+			Category: ptrString("MATH"),
 		},
 		Reward: models.Reward{
 			Type:        models.BadgeReward,
@@ -63,6 +64,7 @@ func TestEvaluateEvent_SingleEventRule(t *testing.T) {
 				Timestamp: time.Now(),
 			},
 			expectedCount: 1,
+			stubCount:     1,
 		},
 		{
 			name: "matching event but exceeds counts doesn't trigger",
@@ -123,8 +125,8 @@ func TestEvaluateEvent_MilestoneRule(t *testing.T) {
 		ID:        "rule-002",
 		EventType: "COURSE_COMPLETED",
 		Count:     3,
-		Conditions: map[string]string{
-			"category": "MATH",
+		Conditions: &models.RuleConditions{
+			Category: ptrString("MATH"),
 		},
 		Reward: models.Reward{
 			Type:        models.PointsReward,
@@ -214,8 +216,8 @@ func TestEvaluateEvent_DisabledRule(t *testing.T) {
 	rule := models.Rule{
 		ID:        "rule-003",
 		EventType: "COURSE_COMPLETED",
-		Conditions: map[string]string{
-			"category": "MATH",
+		Conditions: &models.RuleConditions{
+			Category: ptrString("MATH"),
 		},
 		Reward: models.Reward{
 			Type:        models.BadgeReward,
@@ -247,8 +249,8 @@ func TestEvaluateEvent_RepositoryError(t *testing.T) {
 		ID:        "rule-004",
 		EventType: "COURSE_COMPLETED",
 		Count:     3,
-		Conditions: map[string]string{
-			"category": "MATH",
+		Conditions: &models.RuleConditions{
+			Category: ptrString("MATH"),
 		},
 		Reward: models.Reward{
 			Type:        models.PointsReward,
@@ -289,4 +291,9 @@ func TestGetMilestoneCount(t *testing.T) {
 	count, err := engine.GetMilestoneCount(context.Background(), userID, eventType, category)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedCount, count)
+}
+
+// Helper function to create a pointer to a string
+func ptrString(s string) *string {
+	return &s
 }

--- a/reward-processor/internal/rules/engine_test.go
+++ b/reward-processor/internal/rules/engine_test.go
@@ -34,12 +34,10 @@ func TestEvaluateEvent_SingleEventRule(t *testing.T) {
 
 	// Define a single event rule
 	rule := models.Rule{
-		ID:        "rule-001",
-		EventType: "COURSE_COMPLETED",
-		Count:     1,
-		Conditions: &models.RuleConditions{
-			Category: ptrString("MATH"),
-		},
+		ID:                 "rule-001",
+		EventType:          "COURSE_COMPLETED",
+		Count:              1,
+		ConditionsCategory: ptrString("MATH"),
 		Reward: models.Reward{
 			Type:        models.BadgeReward,
 			Description: "Math Course Completed",
@@ -122,12 +120,10 @@ func TestEvaluateEvent_MilestoneRule(t *testing.T) {
 
 	// Define a milestone rule
 	rule := models.Rule{
-		ID:        "rule-002",
-		EventType: "COURSE_COMPLETED",
-		Count:     3,
-		Conditions: &models.RuleConditions{
-			Category: ptrString("MATH"),
-		},
+		ID:                 "rule-002",
+		EventType:          "COURSE_COMPLETED",
+		Count:              3,
+		ConditionsCategory: ptrString("MATH"),
 		Reward: models.Reward{
 			Type:        models.PointsReward,
 			Amount:      100,
@@ -214,11 +210,9 @@ func TestEvaluateEvent_DisabledRule(t *testing.T) {
 
 	// Define a disabled rule
 	rule := models.Rule{
-		ID:        "rule-003",
-		EventType: "COURSE_COMPLETED",
-		Conditions: &models.RuleConditions{
-			Category: ptrString("MATH"),
-		},
+		ID:                 "rule-003",
+		EventType:          "COURSE_COMPLETED",
+		ConditionsCategory: ptrString("MATH"),
 		Reward: models.Reward{
 			Type:        models.BadgeReward,
 			Description: "Disabled Rule",
@@ -246,12 +240,10 @@ func TestEvaluateEvent_RepositoryError(t *testing.T) {
 
 	// Define a milestone rule
 	rule := models.Rule{
-		ID:        "rule-004",
-		EventType: "COURSE_COMPLETED",
-		Count:     3,
-		Conditions: &models.RuleConditions{
-			Category: ptrString("MATH"),
-		},
+		ID:                 "rule-004",
+		EventType:          "COURSE_COMPLETED",
+		Count:              3,
+		ConditionsCategory: ptrString("MATH"),
 		Reward: models.Reward{
 			Type:        models.PointsReward,
 			Amount:      100,

--- a/reward-processor/internal/server/server.go
+++ b/reward-processor/internal/server/server.go
@@ -42,7 +42,7 @@ func New(cfg Config) *Server {
 // Start starts the HTTP server
 func (s *Server) Start(db *repository.GormRuleRepository) error {
 	// Create resolver
-	resolver := resolver.NewResolver(db)
+	resolver := resolver.NewResolver(db, s.log)
 
 	// Create GraphQL server
 	srv := handler.New(generated.NewExecutableSchema(generated.Config{

--- a/reward-processor/pkg/models/types.go
+++ b/reward-processor/pkg/models/types.go
@@ -1,9 +1,6 @@
 package models
 
 import (
-	"database/sql/driver"
-	"encoding/json"
-	"errors"
 	"time"
 )
 
@@ -17,43 +14,17 @@ const (
 
 // Rule represents a reward rule
 type Rule struct {
-	ID         string         `json:"id" gorm:"primaryKey"`
-	EventType  string         `json:"event_type"`
-	Count      int            `json:"count,omitempty"`
-	Conditions RuleConditions `json:"conditions" gorm:"type:jsonb"`
-	Reward     Reward         `json:"reward" gorm:"embedded"`
-	Enabled    bool           `json:"enabled"`
+	ID         string          `json:"id" gorm:"primaryKey"`
+	EventType  string          `json:"event_type"`
+	Count      int             `json:"count,omitempty"`
+	Conditions *RuleConditions `json:"conditions" gorm:"type:jsonb"`
+	Reward     Reward          `json:"reward" gorm:"embedded"`
+	Enabled    bool            `json:"enabled"`
 }
 
-// RuleConditions is a custom type to handle map[string]string in GORM
-type RuleConditions map[string]string
-
-// Value implements the driver.Valuer interface for RuleConditions
-func (rc RuleConditions) Value() (driver.Value, error) {
-	if rc == nil {
-		return nil, nil
-	}
-	return json.Marshal(rc)
-}
-
-// Scan implements the sql.Scanner interface for RuleConditions
-func (rc *RuleConditions) Scan(value interface{}) error {
-	if value == nil {
-		*rc = make(RuleConditions)
-		return nil
-	}
-
-	var bytes []byte
-	switch v := value.(type) {
-	case []byte:
-		bytes = v
-	case string:
-		bytes = []byte(v)
-	default:
-		return errors.New("type assertion to []byte failed")
-	}
-
-	return json.Unmarshal(bytes, rc)
+// RuleConditions represents a set of "extra" attributes for trigger criteria
+type RuleConditions struct {
+	Category *string `json:"category"`
 }
 
 // Reward represents a reward definition

--- a/reward-processor/pkg/models/types.go
+++ b/reward-processor/pkg/models/types.go
@@ -7,9 +7,6 @@ import (
 	"time"
 )
 
-// RuleType represents the type of rule
-type RuleType string
-
 // RewardType represents the type of reward
 type RewardType string
 
@@ -21,7 +18,6 @@ const (
 // Rule represents a reward rule
 type Rule struct {
 	ID         string         `json:"id" gorm:"primaryKey"`
-	Type       RuleType       `json:"type"`
 	EventType  string         `json:"event_type"`
 	Count      int            `json:"count,omitempty"`
 	Conditions RuleConditions `json:"conditions" gorm:"type:jsonb"`

--- a/reward-processor/pkg/models/types.go
+++ b/reward-processor/pkg/models/types.go
@@ -14,17 +14,12 @@ const (
 
 // Rule represents a reward rule
 type Rule struct {
-	ID         string          `json:"id" gorm:"primaryKey"`
-	EventType  string          `json:"event_type"`
-	Count      int             `json:"count,omitempty"`
-	Conditions *RuleConditions `json:"conditions" gorm:"type:jsonb"`
-	Reward     Reward          `json:"reward" gorm:"embedded"`
-	Enabled    bool            `json:"enabled"`
-}
-
-// RuleConditions represents a set of "extra" attributes for trigger criteria
-type RuleConditions struct {
-	Category *string `json:"category"`
+	ID                 string  `json:"id" gorm:"primaryKey"`
+	EventType          string  `json:"event_type"`
+	Count              int     `json:"count,omitempty"`
+	ConditionsCategory *string `json:"conditions_category" gorm:"column:conditions_category"`
+	Reward             Reward  `json:"reward" gorm:"embedded"`
+	Enabled            bool    `json:"enabled"`
 }
 
 // Reward represents a reward definition

--- a/stress-test/Makefile
+++ b/stress-test/Makefile
@@ -1,6 +1,6 @@
 
 # === Stress Testing ===
-STRESS_RATE ?= 10
+STRESS_RATE ?= 20
 STRESS_DURATION ?= 5s
 TARGET_FILE ?= targets/events.txt
 REPORT_FILE ?= results/report.bin

--- a/stress-test/bodies/course_programming_completed.json
+++ b/stress-test/bodies/course_programming_completed.json
@@ -1,0 +1,8 @@
+{
+    "user_id": "abc-678",
+    "event_type": "COURSE_COMPLETED",
+    "course_id": "course-xyz",
+    "category": "PROGRAMMING",
+    "timestamp": "2025-06-16T14:00:00Z"
+  }
+  

--- a/stress-test/targets/events.txt
+++ b/stress-test/targets/events.txt
@@ -10,3 +10,7 @@ Content-Type: application/json
 POST http://localhost:8081/events
 Content-Type: application/json
 @bodies/course_math_completed.json
+
+POST http://localhost:8081/events
+Content-Type: application/json
+@bodies/course_programming_completed.json


### PR DESCRIPTION
- Update `conditions` GraphQL type.
- Validate `reward_type` by adding GraphQL enum.
-  Remove deprecated attribute `type`.
- Add Unit tests.
- Add Load Test Scripts and Update Rate settings.
- Update README.